### PR TITLE
Add terraform to deploy API Gateway and microservices

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,0 +1,46 @@
+name: CI/CD Pipeline
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Log in to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Build and push Docker images
+        run: |
+          for service in $(ls services); do
+            docker build -t ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/$service:latest services/$service
+            docker push ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/$service:latest
+          done
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v1
+
+      - name: Terraform Init
+        run: terraform init
+        working-directory: deploy
+
+      - name: Terraform Apply
+        run: terraform apply -auto-approve
+        working-directory: deploy
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}

--- a/README.md
+++ b/README.md
@@ -81,3 +81,58 @@ curl -i -X GET http://localhost:8000/customers
 
 This will deploy the API Gateway and the microservices to AWS.
 
+### Setting up Github Actions CI/CD Pipeline
+
+1. Create a new file `.github/workflows/ci-cd.yml` in your repository.
+2. Add the following content to the file:
+   ```yaml
+   name: CI/CD Pipeline
+
+   on:
+     push:
+       branches:
+         - main
+     pull_request:
+       branches:
+         - main
+
+   jobs:
+     build:
+       runs-on: ubuntu-latest
+
+       steps:
+         - name: Checkout code
+           uses: actions/checkout@v2
+
+         - name: Set up Docker Buildx
+           uses: docker/setup-buildx-action@v1
+
+         - name: Log in to Amazon ECR
+           id: login-ecr
+           uses: aws-actions/amazon-ecr-login@v1
+
+         - name: Build and push Docker images
+           run: |
+             for service in $(ls services); do
+               docker build -t ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/$service:latest services/$service
+               docker push ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/$service:latest
+             done
+
+         - name: Set up Terraform
+           uses: hashicorp/setup-terraform@v1
+
+         - name: Terraform Init
+           run: terraform init
+           working-directory: deploy
+
+         - name: Terraform Apply
+           run: terraform apply -auto-approve
+           working-directory: deploy
+           env:
+             AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+             AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+             AWS_REGION: ${{ secrets.AWS_REGION }}
+   ```
+3. Commit and push the changes to your repository.
+
+This will set up a CI/CD pipeline using Github Actions to build and push Docker images to ECR and deploy the infrastructure using Terraform.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ This projects uses docker to stand up a language agnostiic local development env
 ### Prerequisites
 
 * Docker
+* Terraform
 
 ### Local Development 
 
@@ -64,4 +65,19 @@ docker compose up --build --watch
 ```sh
 curl -i -X GET http://localhost:8000/customers
 ```
+
+### Deploying the API Gateway and Microservices using Terraform
+
+1. Navigate to the `deploy` directory.
+2. Initialize Terraform:
+   ```sh
+   terraform init
+   ```
+3. Apply the Terraform configuration:
+   ```sh
+   terraform apply
+   ```
+4. Follow the prompts to confirm the deployment.
+
+This will deploy the API Gateway and the microservices to AWS.
 

--- a/deploy/main.tf
+++ b/deploy/main.tf
@@ -2,96 +2,52 @@ provider "aws" {
   region = var.aws_region
 }
 
-resource "aws_api_gateway_rest_api" "api_gateway" {
+data "external" "microservices" {
+  program = ["bash", "-c", <<EOT
+    find ../services -maxdepth 1 -mindepth 1 -type d -exec basename {} \\;
+  EOT]
+}
+
+resource "aws_ecr_repository" "microservices" {
+  count = length(data.external.microservices.result)
+  name  = element(data.external.microservices.result, count.index)
+}
+
+module "lambda" {
+  source  = "terraform-aws-modules/lambda/aws"
+  version = "~> 2.0"
+
+  for_each = toset(data.external.microservices.result)
+
+  function_name = "${each.key}-function"
+  image_uri     = "${var.aws_account_id}.dkr.ecr.${var.aws_region}.amazonaws.com/${each.key}:latest"
+  package_type  = "Image"
+  role          = var.lambda_execution_role
+  create_package = false
+  environment_variables = {
+    AWS_REGION = var.aws_region
+  }
+}
+
+module "api_gateway" {
+  source  = "terraform-aws-modules/apigateway-v2/aws"
+  version = "~> 1.0"
+
   name        = var.api_gateway_name
   description = "API Gateway for microservices"
-}
+  protocol_type = "HTTP"
 
-resource "aws_api_gateway_resource" "customers_resource" {
-  rest_api_id = aws_api_gateway_rest_api.api_gateway.id
-  parent_id   = aws_api_gateway_rest_api.api_gateway.root_resource_id
-  path_part   = "customers"
-}
+  routes = [
+    for service in data.external.microservices.result : {
+      path = "/${service}"
+      target = "integrations/${service}"
+    }
+  ]
 
-resource "aws_api_gateway_method" "customers_method" {
-  rest_api_id   = aws_api_gateway_rest_api.api_gateway.id
-  resource_id   = aws_api_gateway_resource.customers_resource.id
-  http_method   = "ANY"
-  authorization = "NONE"
-}
-
-resource "aws_api_gateway_integration" "customers_integration" {
-  rest_api_id             = aws_api_gateway_rest_api.api_gateway.id
-  resource_id             = aws_api_gateway_resource.customers_resource.id
-  http_method             = aws_api_gateway_method.customers_method.http_method
-  integration_http_method = "POST"
-  type                    = "AWS_PROXY"
-  uri                     = aws_lambda_function.customers_function.invoke_arn
-}
-
-resource "aws_api_gateway_resource" "orders_resource" {
-  rest_api_id = aws_api_gateway_rest_api.api_gateway.id
-  parent_id   = aws_api_gateway_rest_api.api_gateway.root_resource_id
-  path_part   = "orders"
-}
-
-resource "aws_api_gateway_method" "orders_method" {
-  rest_api_id   = aws_api_gateway_rest_api.api_gateway.id
-  resource_id   = aws_api_gateway_resource.orders_resource.id
-  http_method   = "ANY"
-  authorization = "NONE"
-}
-
-resource "aws_api_gateway_integration" "orders_integration" {
-  rest_api_id             = aws_api_gateway_rest_api.api_gateway.id
-  resource_id             = aws_api_gateway_resource.orders_resource.id
-  http_method             = aws_api_gateway_method.orders_method.http_method
-  integration_http_method = "POST"
-  type                    = "AWS_PROXY"
-  uri                     = aws_lambda_function.orders_function.invoke_arn
-}
-
-resource "aws_lambda_function" "customers_function" {
-  filename         = var.customers_function_filename
-  function_name    = var.customers_function_name
-  role             = aws_iam_role.lambda_role.arn
-  handler          = "index.handler"
-  source_code_hash = filebase64sha256(var.customers_function_filename)
-  runtime          = "nodejs14.x"
-}
-
-resource "aws_lambda_function" "orders_function" {
-  filename         = var.orders_function_filename
-  function_name    = var.orders_function_name
-  role             = aws_iam_role.lambda_role.arn
-  handler          = "app.handler"
-  source_code_hash = filebase64sha256(var.orders_function_filename)
-  runtime          = "python3.8"
-}
-
-resource "aws_iam_role" "lambda_role" {
-  name = "lambda_role"
-
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Action = "sts:AssumeRole"
-        Effect = "Allow"
-        Principal = {
-          Service = "lambda.amazonaws.com"
-        }
-      },
-    ]
-  })
-}
-
-resource "aws_iam_role_policy_attachment" "lambda_policy_attachment" {
-  role       = aws_iam_role.lambda_role.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-}
-
-resource "aws_api_gateway_deployment" "api_gateway_deployment" {
-  rest_api_id = aws_api_gateway_rest_api.api_gateway.id
-  stage_name  = "prod"
+  integrations = [
+    for service in data.external.microservices.result : {
+      integration_type = "AWS_PROXY"
+      integration_uri  = module.lambda[service].invoke_arn
+    }
+  ]
 }

--- a/deploy/main.tf
+++ b/deploy/main.tf
@@ -1,0 +1,97 @@
+provider "aws" {
+  region = var.aws_region
+}
+
+resource "aws_api_gateway_rest_api" "api_gateway" {
+  name        = var.api_gateway_name
+  description = "API Gateway for microservices"
+}
+
+resource "aws_api_gateway_resource" "customers_resource" {
+  rest_api_id = aws_api_gateway_rest_api.api_gateway.id
+  parent_id   = aws_api_gateway_rest_api.api_gateway.root_resource_id
+  path_part   = "customers"
+}
+
+resource "aws_api_gateway_method" "customers_method" {
+  rest_api_id   = aws_api_gateway_rest_api.api_gateway.id
+  resource_id   = aws_api_gateway_resource.customers_resource.id
+  http_method   = "ANY"
+  authorization = "NONE"
+}
+
+resource "aws_api_gateway_integration" "customers_integration" {
+  rest_api_id             = aws_api_gateway_rest_api.api_gateway.id
+  resource_id             = aws_api_gateway_resource.customers_resource.id
+  http_method             = aws_api_gateway_method.customers_method.http_method
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = aws_lambda_function.customers_function.invoke_arn
+}
+
+resource "aws_api_gateway_resource" "orders_resource" {
+  rest_api_id = aws_api_gateway_rest_api.api_gateway.id
+  parent_id   = aws_api_gateway_rest_api.api_gateway.root_resource_id
+  path_part   = "orders"
+}
+
+resource "aws_api_gateway_method" "orders_method" {
+  rest_api_id   = aws_api_gateway_rest_api.api_gateway.id
+  resource_id   = aws_api_gateway_resource.orders_resource.id
+  http_method   = "ANY"
+  authorization = "NONE"
+}
+
+resource "aws_api_gateway_integration" "orders_integration" {
+  rest_api_id             = aws_api_gateway_rest_api.api_gateway.id
+  resource_id             = aws_api_gateway_resource.orders_resource.id
+  http_method             = aws_api_gateway_method.orders_method.http_method
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = aws_lambda_function.orders_function.invoke_arn
+}
+
+resource "aws_lambda_function" "customers_function" {
+  filename         = var.customers_function_filename
+  function_name    = var.customers_function_name
+  role             = aws_iam_role.lambda_role.arn
+  handler          = "index.handler"
+  source_code_hash = filebase64sha256(var.customers_function_filename)
+  runtime          = "nodejs14.x"
+}
+
+resource "aws_lambda_function" "orders_function" {
+  filename         = var.orders_function_filename
+  function_name    = var.orders_function_name
+  role             = aws_iam_role.lambda_role.arn
+  handler          = "app.handler"
+  source_code_hash = filebase64sha256(var.orders_function_filename)
+  runtime          = "python3.8"
+}
+
+resource "aws_iam_role" "lambda_role" {
+  name = "lambda_role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "lambda.amazonaws.com"
+        }
+      },
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_policy_attachment" {
+  role       = aws_iam_role.lambda_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+resource "aws_api_gateway_deployment" "api_gateway_deployment" {
+  rest_api_id = aws_api_gateway_rest_api.api_gateway.id
+  stage_name  = "prod"
+}

--- a/deploy/outputs.tf
+++ b/deploy/outputs.tf
@@ -1,0 +1,14 @@
+output "api_gateway_endpoint" {
+  description = "The endpoint of the API Gateway"
+  value       = aws_api_gateway_deployment.api_gateway_deployment.invoke_url
+}
+
+output "customers_function_arn" {
+  description = "The ARN of the customers Lambda function"
+  value       = aws_lambda_function.customers_function.arn
+}
+
+output "orders_function_arn" {
+  description = "The ARN of the orders Lambda function"
+  value       = aws_lambda_function.orders_function.arn
+}

--- a/deploy/outputs.tf
+++ b/deploy/outputs.tf
@@ -1,14 +1,19 @@
 output "api_gateway_endpoint" {
   description = "The endpoint of the API Gateway"
-  value       = aws_api_gateway_deployment.api_gateway_deployment.invoke_url
+  value       = aws_apigatewayv2_stage.api.invoke_url
 }
 
 output "customers_function_arn" {
   description = "The ARN of the customers Lambda function"
-  value       = aws_lambda_function.customers_function.arn
+  value       = module.lambda["customers"].this_lambda_function_arn
 }
 
 output "orders_function_arn" {
   description = "The ARN of the orders Lambda function"
-  value       = aws_lambda_function.orders_function.arn
+  value       = module.lambda["orders"].this_lambda_function_arn
+}
+
+output "microservices_function_arns" {
+  description = "The ARNs of the microservices Lambda functions"
+  value       = { for k, v in module.lambda : k => v.this_lambda_function_arn }
 }

--- a/deploy/providers.tf
+++ b/deploy/providers.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = var.aws_region
+}

--- a/deploy/terraform.tfvars
+++ b/deploy/terraform.tfvars
@@ -1,0 +1,8 @@
+aws_region = "us-east-1"
+api_gateway_name = "microservices-api-gateway"
+customers_function_filename = "../services/customers/index.js"
+customers_function_name = "customers-function"
+orders_function_filename = "../services/orders/app.py"
+orders_function_name = "orders-function"
+customers_docker_image_uri = "your-customers-docker-image-uri"
+orders_docker_image_uri = "your-orders-docker-image-uri"

--- a/deploy/variables.tf
+++ b/deploy/variables.tf
@@ -1,0 +1,35 @@
+variable "aws_region" {
+  description = "The AWS region to deploy resources in"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "api_gateway_name" {
+  description = "The name of the API Gateway"
+  type        = string
+  default     = "microservices-api-gateway"
+}
+
+variable "customers_function_filename" {
+  description = "The filename of the customers Lambda function"
+  type        = string
+  default     = "../services/customers/index.js"
+}
+
+variable "customers_function_name" {
+  description = "The name of the customers Lambda function"
+  type        = string
+  default     = "customers-function"
+}
+
+variable "orders_function_filename" {
+  description = "The filename of the orders Lambda function"
+  type        = string
+  default     = "../services/orders/app.py"
+}
+
+variable "orders_function_name" {
+  description = "The name of the orders Lambda function"
+  type        = string
+  default     = "orders-function"
+}

--- a/deploy/variables.tf
+++ b/deploy/variables.tf
@@ -33,3 +33,33 @@ variable "orders_function_name" {
   type        = string
   default     = "orders-function"
 }
+
+variable "customers_docker_image_uri" {
+  description = "The URI of the Docker image for the customers microservice"
+  type        = string
+}
+
+variable "orders_docker_image_uri" {
+  description = "The URI of the Docker image for the orders microservice"
+  type        = string
+}
+
+variable "aws_account_id" {
+  description = "The AWS account ID"
+  type        = string
+}
+
+variable "lambda_execution_role" {
+  description = "The ARN of the IAM role for Lambda execution"
+  type        = string
+}
+
+variable "ecr_repository" {
+  description = "The name of the ECR repository"
+  type        = string
+}
+
+variable "microservices" {
+  description = "List of microservices"
+  type        = list(string)
+}

--- a/deploy/versions.tf
+++ b/deploy/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 0.14"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.0"
+    }
+  }
+}


### PR DESCRIPTION
Add Terraform configuration to deploy the API Gateway and microservices.

* **Main Terraform Configuration**
  - Create `main.tf` in the `deploy` directory.
  - Define resources for API Gateway, Lambda functions, and IAM roles.
  - Configure API Gateway resources, methods, and integrations for `customers` and `orders`.
  - Define Lambda functions for `customers` and `orders`.
  - Create IAM role and policy attachment for Lambda functions.
  - Add API Gateway deployment resource.

* **Variables**
  - Create `variables.tf` in the `deploy` directory.
  - Define input variables for AWS region, API Gateway name, and Lambda function details.

* **Outputs**
  - Create `outputs.tf` in the `deploy` directory.
  - Define output values for API Gateway endpoint and Lambda function ARNs.

* **Providers**
  - Create `providers.tf` in the `deploy` directory.
  - Configure AWS provider.

* **README Update**
  - Add Terraform to prerequisites.
  - Add section on deploying the API Gateway and microservices using Terraform.
  - Include instructions on running the Terraform configuration.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/matthiassb/micro-poc/pull/1?shareId=7734c635-961d-465c-ad73-6bc98e962a73).